### PR TITLE
Preview tasks

### DIFF
--- a/include/TaskMesher.h
+++ b/include/TaskMesher.h
@@ -30,6 +30,7 @@ private:
 public:
   static const char * empty_mesh;
   bool GetMesh(uint8_t lod, const char ** data, size_t * length) const;
+  void ScaleMesh(float scaleFactor[3]);
 
   CTaskMesher(std::vector<T> segmentation, const zi::vl::vec<size_t, 3> & dim, const std::vector<T> & segments);
   ~CTaskMesher();
@@ -53,6 +54,12 @@ extern "C" {
   void      TaskMesher_GetSimplifiedMesh_uint8(TMesher * taskmesher, uint8_t lod, const char ** data, size_t * length);
   void      TaskMesher_GetSimplifiedMesh_uint16(TMesher * taskmesher, uint8_t lod, const char ** data, size_t * length);
   void      TaskMesher_GetSimplifiedMesh_uint32(TMesher * taskmesher, uint8_t lod, const char ** data, size_t * length);
+  void      TaskMesher_ScaleVolume_uint8(unsigned char * in_volume, size_t from_dim[3], size_t to_dim[3], unsigned char * out_buffer);
+  void      TaskMesher_ScaleVolume_uint16(unsigned char * in_volume, size_t from_dim[3], size_t to_dim[3], unsigned char * out_buffer);
+  void      TaskMesher_ScaleVolume_uint32(unsigned char * in_volume, size_t from_dim[3], size_t to_dim[3], unsigned char * out_buffer);
+  void      TaskMesher_ScaleMesh_uint8(TMesher * taskmesher, float scaleFactor[3]);
+  void      TaskMesher_ScaleMesh_uint16(TMesher * taskmesher, float scaleFactor[3]);
+  void      TaskMesher_ScaleMesh_uint32(TMesher * taskmesher, float scaleFactor[3]);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/TaskMesher.h
+++ b/include/TaskMesher.h
@@ -15,10 +15,11 @@ private:
   bool                              meshed_;
   const zi::vl::vec<size_t, 3>      dim_;
   std::set<T>                       segments_;
+  uint8_t                           miplevels_;
 
 
-  size_t                            meshLength_[5];
-  char                            * meshData_[5];
+  size_t                            meshLength_[256];
+  char                            * meshData_[256];
 
   inline void idxToXYZ(size_t idx, size_t &x, size_t &y, size_t &z) const;
 
@@ -32,7 +33,7 @@ public:
   bool GetMesh(uint8_t lod, const char ** data, size_t * length) const;
   void ScaleMesh(float scaleFactor[3]);
 
-  CTaskMesher(std::vector<T> segmentation, const zi::vl::vec<size_t, 3> & dim, const std::vector<T> & segments);
+  CTaskMesher(std::vector<T> segmentation, const zi::vl::vec<size_t, 3> & dim, const std::vector<T> & segments, uint8_t mipCount);
   ~CTaskMesher();
 
 };
@@ -42,9 +43,9 @@ typedef struct TaskMeshHandle TMesher;
 #ifdef __cplusplus
 extern "C" {
 #endif
-  TMesher * TaskMesher_Generate_uint8(unsigned char * volume, size_t dim[3], uint8_t * segments, uint8_t segmentCount);
-  TMesher * TaskMesher_Generate_uint16(unsigned char * volume, size_t dim[3], uint16_t * segments, uint16_t segmentCount);
-  TMesher * TaskMesher_Generate_uint32(unsigned char * volume, size_t dim[3], uint32_t * segments, uint32_t segmentCount);
+  TMesher * TaskMesher_Generate_uint8(unsigned char * volume, size_t dim[3], uint8_t * segments, uint8_t segmentCount, uint8_t mipCount);
+  TMesher * TaskMesher_Generate_uint16(unsigned char * volume, size_t dim[3], uint16_t * segments, uint16_t segmentCount, uint8_t mipCount);
+  TMesher * TaskMesher_Generate_uint32(unsigned char * volume, size_t dim[3], uint32_t * segments, uint32_t segmentCount, uint8_t mipCount);
   void      TaskMesher_Release_uint8(TMesher * taskmesher);
   void      TaskMesher_Release_uint16(TMesher * taskmesher);
   void      TaskMesher_Release_uint32(TMesher * taskmesher);

--- a/include/TaskMesher_Impl.h
+++ b/include/TaskMesher_Impl.h
@@ -123,11 +123,7 @@ volume_(std::move(segmentation)), meshed_(false), dim_(dim), segments_(segments.
         std::cout << "Initial (lossless) simplification: " << t.elapsed<double>() << " s\n";
         t.reset();
 
-        for (int mip = 1; mip <= 3; ++mip) {
-          if (miplevels_ == mip) {
-            break;
-          }
-
+        for (int mip = 1; mip < miplevels_; ++mip) {
           s.optimize(s.face_count() / 8, 1 << (10*(mip - 1)));
           strip = CreateDegTriStrip(s);
           meshLength_[1 + mip] = strip.size() * sizeof(float);

--- a/include/TaskMesher_Impl.h
+++ b/include/TaskMesher_Impl.h
@@ -43,7 +43,7 @@ void ScaleVolume(const T * org_buf, size_t from_dim[3], size_t to_dim[3], T * sc
 template<typename T>
 void CTaskMesher<T>::ScaleMesh(float scaleFactor[3])
 {
-  for (int lod = 0; lod < 5; ++lod) {
+  for (int lod = 0; lod < 1 + miplevels_; ++lod) {
     if (meshData_[lod]) {
       float * data = (float*)(meshData_[lod]);
       int length = meshLength_[lod] / sizeof(float);

--- a/js/rtm.config.json
+++ b/js/rtm.config.json
@@ -1,0 +1,4 @@
+{
+    "overview_meshes_bucket": "overview_meshes_dev",
+    "eyewire_server": "http://nkem.eyewire.org"
+}

--- a/src/TaskMesher.cpp
+++ b/src/TaskMesher.cpp
@@ -69,3 +69,34 @@ extern "C" void TaskMesher_GetSimplifiedMesh_uint32(TMesher * taskmesher, uint8_
 }
 
 /*****************************************************************/
+
+extern "C" void TaskMesher_ScaleVolume_uint8(unsigned char * in_volume, size_t from_dim[3], size_t to_dim[3], unsigned char * out_buffer) {
+  ScaleVolume((uint8_t*)in_volume, from_dim, to_dim, (uint8_t*)out_buffer);
+}
+
+extern "C" void TaskMesher_ScaleVolume_uint16(unsigned char * in_volume, size_t from_dim[3], size_t to_dim[3], unsigned char * out_buffer) {
+  ScaleVolume((uint16_t*)in_volume, from_dim, to_dim, (uint16_t*)out_buffer);
+}
+
+extern "C" void TaskMesher_ScaleVolume_uint32(unsigned char * in_volume, size_t from_dim[3], size_t to_dim[3], unsigned char * out_buffer) {
+  ScaleVolume((uint32_t*)in_volume, from_dim, to_dim, (uint32_t*)out_buffer);
+}
+
+/*****************************************************************/
+
+extern "C" void TaskMesher_ScaleMesh_uint8(TMesher * taskmesher, float scaleFactor[3])
+{
+  ((CTaskMesher<uint8_t>*)(taskmesher))->ScaleMesh(scaleFactor);
+}
+
+extern "C" void TaskMesher_ScaleMesh_uint16(TMesher * taskmesher, float scaleFactor[3])
+{
+  ((CTaskMesher<uint16_t>*)(taskmesher))->ScaleMesh(scaleFactor);
+}
+
+extern "C" void TaskMesher_ScaleMesh_uint32(TMesher * taskmesher, float scaleFactor[3])
+{
+  ((CTaskMesher<uint32_t>*)(taskmesher))->ScaleMesh(scaleFactor);
+}
+
+/*****************************************************************/

--- a/src/TaskMesher.cpp
+++ b/src/TaskMesher.cpp
@@ -2,22 +2,22 @@
 
 /*****************************************************************/
 
-extern "C" TMesher * TaskMesher_Generate_uint8(unsigned char * volume, size_t dim[3], uint8_t * segments, uint8_t segmentCount) {
+extern "C" TMesher * TaskMesher_Generate_uint8(unsigned char * volume, size_t dim[3], uint8_t * segments, uint8_t segmentCount, uint8_t mipCount) {
   std::vector<uint8_t> seg(segments, segments + segmentCount);
   std::vector<uint8_t> vol((uint8_t *)volume, (uint8_t *)volume + dim[0]*dim[1]*dim[2]);
-  return (TMesher *)(new CTaskMesher<uint8_t>(std::move(vol), zi::vl::vec<size_t, 3>(dim[0], dim[1], dim[2]), seg));
+  return (TMesher *)(new CTaskMesher<uint8_t>(std::move(vol), zi::vl::vec<size_t, 3>(dim[0], dim[1], dim[2]), seg, mipCount));
 }
 
-extern "C" TMesher * TaskMesher_Generate_uint16(unsigned char * volume, size_t dim[3], uint16_t * segments, uint16_t segmentCount) {
+extern "C" TMesher * TaskMesher_Generate_uint16(unsigned char * volume, size_t dim[3], uint16_t * segments, uint16_t segmentCount, uint8_t mipCount) {
   std::vector<uint16_t> seg(segments, segments + segmentCount);
   std::vector<uint16_t> vol((uint16_t *)volume, (uint16_t *)volume + dim[0]*dim[1]*dim[2]);
-  return (TMesher *)(new CTaskMesher<uint16_t>(std::move(vol), zi::vl::vec<size_t, 3>(dim[0], dim[1], dim[2]), seg));
+  return (TMesher *)(new CTaskMesher<uint16_t>(std::move(vol), zi::vl::vec<size_t, 3>(dim[0], dim[1], dim[2]), seg, mipCount));
 }
 
-extern "C" TMesher * TaskMesher_Generate_uint32(unsigned char * volume, size_t dim[3], uint32_t * segments, uint32_t segmentCount) {
+extern "C" TMesher * TaskMesher_Generate_uint32(unsigned char * volume, size_t dim[3], uint32_t * segments, uint32_t segmentCount, uint8_t mipCount) {
   std::vector<uint32_t> seg(segments, segments + segmentCount);
   std::vector<uint32_t> vol((uint32_t *)volume, (uint32_t *)volume + dim[0]*dim[1]*dim[2]);
-  return (TMesher *)(new CTaskMesher<uint32_t>(std::move(vol), zi::vl::vec<size_t, 3>(dim[0], dim[1], dim[2]), seg));
+  return (TMesher *)(new CTaskMesher<uint32_t>(std::move(vol), zi::vl::vec<size_t, 3>(dim[0], dim[1], dim[2]), seg, mipCount));
 }
 
 /*****************************************************************/


### PR DESCRIPTION
Adding preview for task meshes:

Each time a high priority mesh is requested, it is moved to the low priority queue, but a copy of the high-priority entry is generated with a down-scaled volume (128,128,128). This preview can be meshed almost instantaneously (except for downloading the full scale segmentation, if necessary).

Hack: Only one simplified mesh is generated for the preview, but in order to keep Eyewire updating correctly at all zoom levels, it is written to disk for every MIP level. (0.dstrip, 1.dstrip, 2.dstrip)

Also: One thread is always reserved for high-priority (preview) meshes. Before, it was possible (and very common) that huge low-priority tasks were processed on all threads while new high-priority tasks arrived.

